### PR TITLE
fix: apply validation rules only to Sepay payment method

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
     "provider": "FriendsOfBotble\\SePay\\Providers\\SePayServiceProvider",
     "author": "Friends Of Botble",
     "url": "https://friendsofbotble.com",
-    "version": "2.0.3",
+    "version": "2.0.4",
     "description": "Tích hợp xác nhận thanh toán tự động qua SePay vào Botble CMS.",
     "minimum_core_version": "7.3.2"
 }

--- a/src/Providers/HookServiceProvider.php
+++ b/src/Providers/HookServiceProvider.php
@@ -154,7 +154,7 @@ class HookServiceProvider extends ServiceProvider
     protected function registerRequestRules(): void
     {
         add_filter('core_request_rules', function (array $rules, Request $request) {
-            if ($request instanceof PaymentMethodRequest) {
+            if ($request instanceof PaymentMethodRequest && $request->post('type') === SEPAY_PAYMENT_METHOD_NAME) {
                 $rules = array_merge($rules, $this->getPaymentMethodRules($request));
             }
 


### PR DESCRIPTION
Fixes #4

Previously, Sepay-specific validation rules were applied to all payment methods, causing the prefix dropdown to be non-functional. This fix ensures the rules only apply when configuring Sepay.